### PR TITLE
Request to add Douban API for sharing URL.

### DIFF
--- a/sharing-services.md
+++ b/sharing-services.md
@@ -7,6 +7,7 @@ These can be used in your [Sharing settings](https://feedbin.me/settings/sharing
 | ------------------- | ---------------------------------------------------------------------------------- |
 | App.net             | `https://alpha.app.net/intent/post?text=${title}+${url}`                           |
 | Buffer              | `http://bufferapp.com/add?url=${url}&text=${title}`                                |
+| Douban              | `http://www.douban.com/recommend/?url=${url}&title=${title}`                       |
 | Email               | `mailto:?subject=${title}&body=${url}`                                             |
 | Evernote            | `https://www.evernote.com/clip.action?url=${url}&title=${title}`                   |
 | Facebook            | `http://www.facebook.com/sharer.php?u=${url}&t=${title}`                           |


### PR DESCRIPTION
[Douban (豆瓣)](http://www.douban.com) is a culture production (book, movie, music and more) sharing and comunication community in China.

The users in Douban often share web articles from feed or other sites to their followers. This sharing URL will be useful for Chinese.
